### PR TITLE
Multi-query search parsing mostly working

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,7 @@ class HomeController < ApplicationController
     # puts "USING FUZZY SEARCH? #{@use_fuzzy_search}"
 
     # @results = Card.search(params[:search], params[:use_fuzzy_search])
-    @results, @matched_terms = Card.search(params[:search], params[:use_fuzzy_search])
+    @results, @matched_terms, @multisearch = Card.search(params[:search], params[:use_fuzzy_search])
     # search_as_array = params[:search].split(//)
 
     # puts "MATCHED TERMS RECIEVED #{@matched_terms}"

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -14,22 +14,29 @@ class Card < ActiveRecord::Base
 
   def self.search search, use_fuzzy_search
     unless search.blank?
-      @results = Hash.new
 
       exclude_columns = ['id', 'image_url', 'created_at', 'updated_at']
       columns = Card.attribute_names - exclude_columns
 
       search_queries = search.split(', ')
-      # puts "QUERIES = #{search_queries}"
+
+      if search_queries.count > 1
+        @results
+        @multisearch = true
+      else
+        @results = Hash.new
+        @multisearch = false
+      end
 
       @cards = []
       t_results = []
 
       @matched_terms = []
 
-      # TODO Cannot be done (easily?) without the Slot model.
+      # FIXME breaks in some edge cases
+      # 'village, 5' vs '5, village'
+      # 'trashing, 4'
       search_queries.each do |query|
-
         columns.each do |col|
           if use_fuzzy_search && !is_numeric?(query)
             cards = Card.send("find_by_fuzzy_#{col}", query)
@@ -40,101 +47,43 @@ class Card < ActiveRecord::Base
               # XXX scope method = requires specific thing
               # cards = Card.send( "_#{col}", query )
             else
-              cards = Card.where("#{col} LIKE ?","%#{query}%")
-
-
-
-
-
-              # # cards = Card.where("#{col} LIKE ?","%#{query}%")
-              # puts ">>> PARSING SECOND QUERY on #{query}"
-              # # XXX complications from Livesearch on this (no longer blank after 1st character)
-              # @results.each do |k, v|
-              #   puts "Column = #{col}"
-              #   puts "#{k} PARSING FROM"
-              #   v.each do |c|
-              #     puts c.name
-              #   end
-              #
-              #   columns.each do|
-              #   cards = v.where("#{col} LIKE ?","%#{query}%")
-              # end
-              # # cards = @results[col].where("#{col} LIKE ?","%#{query}%") unless @results[col].blank?
-              # puts "RESULTING CARDS"
-              # cards.each do |c|
-              #   puts c.name
-              # end
-              # #
-              # puts "Test"
-
-              # puts "result of parse in #{col}: #{cards.blank?}"
-
-              # puts "BEFORE #{cards.count}"
-              # cards = @@matched_cards.where("#{col} LIKE ?","%#{query}%")
-              # cards = Card.where(@@matched_cards.map(&:id).uniq).map{|card| card.}
-
-              # where("#{col} LIKE ?","%#{query}%")
-              # puts "NARROWED DOWN = #{cards.count}"
-
-              # NOTE CHALLENGE IS "DIGGING" DOWN TO THE ActiveRecord AND QUERYING IT
-              # next is the challenge of not overriding array/AR if it finds nothing in field
-              # other_results = cards.where("cost LIKE ?", 3)
-              #
-              # unless other_results.blank?
-              #   other_results.each do |card|
-              #     # v.each do |card|
-              #       p "TEST Card = #{card[:name]}"
-              #     # end
-              #   end
-              # end
-              # puts "TEST = #{cards.where("cost LIKE ?", 3)}"
-
-              # puts "TEST = #{@@matched_cards}"
-
-
-              # puts @results.where("#{col} LIKE ?","%#{query}%")
-              # puts Card.where(@results[col].map(&:card_id).uniq)
-
-              # @results.where("#{col} LIKE ?","%#{query}%")
-
-              # puts "TEST #{ @results.select{ |c| c["#{col}"] == query}  } "
-
-
+              # XXX special case for if seaching CATEGORY column
               # cards = Card.where("#{col} LIKE ?","%#{query}%")
-
-              # cards = @results.select(|card|           )
-              # cards = Card.where(@results[col].map(&:col).uniq)
+              # cards ||= @results.where("#{col} LIKE ?","%#{query}%")
+              cards = @results.where("#{col} LIKE ?","%#{query}%")
+              puts "NO RESULTS? #{cards.empty?}"
+              # cards << @results.where("#{col} LIKE ?","%#{query}%") unless @results.where("#{col} LIKE ?","%#{query}%").blank?
             end
           end
 
-          # unless cards.empty?
-          unless cards.blank?
-            @results[col]  = cards
-            # @@matched_cards << cards
+          unless cards.empty?
+          # unless cards.blank?
+            unless search_queries.count > 1
+              @results[col]  = cards
+            else
+              @results = cards
+              # @matched_terms = []
+            end
 
-            # unless col == "name"
-              cards.each do |c|
+            cards.each do |c|
+              unless col == "cost"
+                split_terms = c["#{col}"].split(', ')
 
-                unless col == "cost"
-                  split_terms = c["#{col}"].split(', ')
-
-                  split_terms.each do |term|
-                    # puts "#{term} vs #{query} is #{term.include? query}"
-                    if term.downcase.include? query.downcase
-                      @matched_terms << "<b>#{col}</b>: #{term}"
-                      @matched_terms.uniq!
-                    end
+                split_terms.each do |term|
+                  if term.downcase.include? query.downcase
+                    @matched_terms << "<b>#{col}</b>: #{term}"
+                    @matched_terms.uniq!
                   end
-                else
-                  @matched_terms << "<b>#{col}</b>: #{c["#{col}"]}"
-                  @matched_terms.uniq!
                 end
+              else
+                @matched_terms << "<b>#{col}</b>: #{c["#{col}"]}"
+                @matched_terms.uniq!
               end
-            # end
-            # puts "Matched terms array #{@matched_terms}"
+            end
           end
         end
       end
+
       # WORKING
       # columns.each do |col|
       #   if use_fuzzy_search && !is_numeric?(search)
@@ -168,11 +117,11 @@ class Card < ActiveRecord::Base
       # XXX FOR TESTING
       # puts ">>>>>>>Results #{@results}"
       #
-      @results.each do |k,v|
-        v.each do |card|
-          p "Card = #{card[:name]} in #{k}"
-        end
-      end
+      # @results.each do |k,v|
+      #   v.each do |card|
+      #     p "Card = #{card[:name]} in #{k}"
+      #   end
+      # end
 
       # puts "FLATTEN 1x #{@results.flatten(1)}"
       # puts "FLATTEN 2x #{@results.flatten}"
@@ -187,7 +136,7 @@ class Card < ActiveRecord::Base
 
 
 
-    return [@results, @matched_terms]
+    return [@results, @matched_terms, @multisearch]
   end
 
    def self.is_numeric?(obj)

--- a/app/views/cards/_cards.html.erb
+++ b/app/views/cards/_cards.html.erb
@@ -4,13 +4,23 @@
 
 <!-- XXX reduncant div? -->
 <div class="results">
-  <% results.each do |k,v| %>
-    <h1><%= k %></h1>
-    <% v.each do |card| %>
-      <!-- NOTE this displays the text of the matching category -->
-      <!-- TODO better support for comma-separated fields -->
-      <%# card[k] %>
-      <%= image_tag(card.image_url, class: 'card_image') %>
+  <% unless multisearch %>
+    <% results.each do |k,v| %>
+      <h1><%= k %></h1>
+      <% v.each do |card| %>
+        <!-- NOTE this displays the text of the matching category -->
+        <!-- TODO better support for comma-separated fields -->
+        <%# card[k] %>
+        <%= image_tag(card.image_url, class: 'card_image') %>
+      <% end %>
+    <% end %>
+
+  <% else %>
+
+    <% results.each do |card| %>
+        <%# image_tag(card.image_url, class: 'card_image') %>
+        <%# card.name %>
+        <%= image_tag(card.image_url, class: 'card_image') %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/home/index.js.erb
+++ b/app/views/home/index.js.erb
@@ -1,2 +1,2 @@
-$('.results').html("<%= escape_javascript(render partial: 'cards/cards', locals: {results: @results}) %>")
+$('.results').html("<%= escape_javascript(render partial: 'cards/cards', locals: {results: @results, multisearch: @multisearch}) %>")
 $('.text_results').html("<%= escape_javascript(render partial: 'cards/text_matches', locals: {matched_terms: @matched_terms}) %>")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,7 +56,8 @@ Card.create!(name: "Village",
             category: "Village/Splitter", #multi-types
             expansion: "Base",
             strategy: "Engine",
-            terminality: "Village")
+            # terminality: "Village")
+            terminality: "Non-Terminal")
 Card.create!(name: "Woodcutter",
             image_url: "http://wiki.dominionstrategy.com/images/thumb/d/d6/Woodcutter.jpg/200px-Woodcutter.jpg",
             cost: 3,
@@ -119,7 +120,7 @@ Card.create!(name: "Moneylender",
             types: "Action",
             category: "Trasher, Trash-For-Benefit",
             expansion: "Base",
-            strategy: "",
+            strategy: "Trashing",
             terminality: "Terminal")
 
 
@@ -129,7 +130,7 @@ Card.create!(name: "Remodel",
             types: "Action",
             category: "Trasher, Trash-For-Benefit", #NOTE more subtypess like this
             expansion: "Base",
-            strategy: "",
+            strategy: "Trashing",
             terminality: "Terminal")
 
 


### PR DESCRIPTION
Tested multi-query search with multiple types of queries. It works somewhat, but there are a number of cases where it fails. It appears to be related to ambiguous grouping names and/or the order in which it prioritizes different fields.

For example, 'village, 5' and '5, village' return different results, when they should return just the one card 'Festival'.

@cbeck
