### PR TITLE
Search refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,20 @@
 source 'https://rubygems.org'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.5'
 
-# #1
 group :production do
-  gem 'pg'
   gem 'rails_12factor'
 end
 
-# #2
-group :development do
-  gem 'sqlite3'
-end
+# group :development do
+  # gem 'sqlite3'
+# end
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0'
 end
 
+gem 'pg'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
@@ -31,3 +28,5 @@ gem 'jquery-rails'
 gem 'bootstrap-sass'
 
 gem 'arel'
+
+gem 'sqlite3_ar_regexp', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.11)
+    sqlite3_ar_regexp (2.1.0)
+      activerecord (>= 3.2, < 5)
+      sqlite3
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -160,7 +163,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
-  sqlite3
+  sqlite3_ar_regexp (~> 2.1)
   uglifier (>= 1.3.0)
 
 BUNDLED WITH

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -62,135 +62,135 @@ class Card < ActiveRecord::Base
   end
 
   # # Experimental version
-  def self.regex_test user_input, columns, slot
-    results_hash = Hash.new
-
-    if user_input.length == 1
-      letter_regex = get_regex_from_partial_string(user_input.first)
-
-      columns.each do |col|
-        test_search = Card.send("_#{col}", letter_regex)
-
-        unless test_search.blank?
-          results_hash[col] = test_search.to_sql
-        end
-      end
-    else
-      term_arr = []
-      index = 0
-      # eval_string =  ""
-      eval_arr =  []
-      eval_hash = Hash.new
-      matched_columns = []
-
-      user_input.each do |query|
-        term_arr << get_regex_from_partial_string(query)
-      end
-
-      puts "term array = #{term_arr}"
-
-      columns.each do |col|
-        cards = Card.send("_#{col}", term_arr[index])
-        # puts "cards from send #{cards}"
-
-        unless cards.empty?
-          # eval_string << ".send(\"_#{col}\", \"#{term_arr[index]}\")"
-          eval_arr << ".send(\"_#{col}\", \"#{term_arr[index]}\")"
-          # eval_hash[col] = ".send(\"_#{col}\", \"#{term_arr[index]}\")"
-          matched_columns << col
-        end
-      end
-
-      # unmatched_columns = columns - matched_columns
-
-
-      # puts "eval string #{eval_string}"
-      # puts "eval string #{eval_hash}"
-      # chain_scopes(eval_string[0])
-      # chain_scopes(columns, eval_string[0], index, term_arr.length)
-
-      # unmatched_columns = columns - matched_columns[0]
-      unmatched_columns = Array.new(columns)
-      unmatched_columns.delete(matched_columns[0])
-
-      # chain_scopes(columns, term_arr, eval_arr[0], index, term_arr.length)
-      index = index + 1
-      results = chain_scopes(unmatched_columns, term_arr, eval_arr[0], index, term_arr.length)
-    end
-
-    # results =
-
-    return results_hash
-  end
+  # def self.regex_test user_input, columns, slot
+  #   results_hash = Hash.new
+  #
+  #   if user_input.length == 1
+  #     letter_regex = get_regex_from_partial_string(user_input.first)
+  #
+  #     columns.each do |col|
+  #       test_search = Card.send("_#{col}", letter_regex)
+  #
+  #       unless test_search.blank?
+  #         results_hash[col] = test_search.to_sql
+  #       end
+  #     end
+  #   else
+  #     term_arr = []
+  #     index = 0
+  #     # eval_string =  ""
+  #     eval_arr =  []
+  #     eval_hash = Hash.new
+  #     matched_columns = []
+  #
+  #     user_input.each do |query|
+  #       term_arr << get_regex_from_partial_string(query)
+  #     end
+  #
+  #     puts "term array = #{term_arr}"
+  #
+  #     columns.each do |col|
+  #       cards = Card.send("_#{col}", term_arr[index])
+  #       # puts "cards from send #{cards}"
+  #
+  #       unless cards.empty?
+  #         # eval_string << ".send(\"_#{col}\", \"#{term_arr[index]}\")"
+  #         eval_arr << ".send(\"_#{col}\", \"#{term_arr[index]}\")"
+  #         # eval_hash[col] = ".send(\"_#{col}\", \"#{term_arr[index]}\")"
+  #         matched_columns << col
+  #       end
+  #     end
+  #
+  #     # unmatched_columns = columns - matched_columns
+  #
+  #
+  #     # puts "eval string #{eval_string}"
+  #     # puts "eval string #{eval_hash}"
+  #     # chain_scopes(eval_string[0])
+  #     # chain_scopes(columns, eval_string[0], index, term_arr.length)
+  #
+  #     # unmatched_columns = columns - matched_columns[0]
+  #     unmatched_columns = Array.new(columns)
+  #     unmatched_columns.delete(matched_columns[0])
+  #
+  #     # chain_scopes(columns, term_arr, eval_arr[0], index, term_arr.length)
+  #     index = index + 1
+  #     results = chain_scopes(unmatched_columns, term_arr, eval_arr[0], index, term_arr.length)
+  #   end
+  #
+  #   # results =
+  #
+  #   return results_hash
+  # end
 
   # ###########################################################################################
   # ###########################################################################################
     # Confirmed version
-  # def self.regex_test user_input, columns, slot
-  #   multi_result = Hash.new
-  #   results_hash = Hash.new
-  #   matched_columns = []
-  #
-  #   user_input.each do |query|
-  #     letter_str = ""
-  #     column_string = ''
-  #     num_matched_terms = 0
-  #     letters = query.first.chars
-  #
-  #     letters.each do |letter|
-  #       if letter === letters.first
-  #         letter_str << "[#{letter}]"
-  #       else
-  #         letter_str <<  ".*?[#{letter}]"
-  #       end
-  #     end
-  #
-  #     if query === user_input.first
-  #       columns.each do |col|
-  #         test_search = Card.send("_#{col}", letter_str)
-  #
-  #         unless test_search.blank?
-  #           results_hash[col] = test_search.to_sql
-  #           matched_columns << col unless matched_columns.include? col
-  #         end
-  #       end
-  #     else
-  #       columns.each do |col|
-  #         if multi_result.count > 0
-  #           hash = multi_result.clone
-  #         else
-  #           hash = results_hash
-  #         end
-  #
-  #         hash.each do |result_key, sql|
-  #           unless result_key.include? col
-  #             test_search = Card.send("_#{col}", letter_str)
-  #             unless test_search.blank?
-  #
-  #               sql_to_chain = test_search.to_sql.gsub("SELECT \"cards\".* FROM \"cards\" WHERE ", "")
-  #
-  #               multi_result["#{result_key} > #{col}"] = sql + " AND " + sql_to_chain
-  #             end
-  #           end
-  #         end
-  #       end
-  #     end
-  #   end
-  #
-  #   unless user_input.count > 1
-  #     results = results_hash
-  #   else
-  #     results = multi_result
-  #
-  #     # split_keys = []
-  #     #
-  #     # multi_result.keys.each do |key|
-  #     #   split_keys << key.split(" > ")
-  #     # end
-  #   end
-  #
-  #   return results
-  # end
+  def self.regex_test user_input, columns, slot
+    multi_result = Hash.new
+    results_hash = Hash.new
+    matched_columns = []
+
+    user_input.each do |query|
+      letter_str = ""
+      column_string = ''
+      num_matched_terms = 0
+      letters = query.first.chars
+
+      letters.each do |letter|
+        if letter === letters.first
+          letter_str << "[#{letter}]"
+        else
+          letter_str <<  ".*?[#{letter}]"
+        end
+      end
+
+      if query === user_input.first
+        columns.each do |col|
+          test_search = Card.send("_#{col}", letter_str)
+
+          unless test_search.blank?
+            results_hash[col] = test_search.to_sql
+            matched_columns << col unless matched_columns.include? col
+          end
+        end
+      else
+        columns.each do |col|
+          if multi_result.count > 0
+            hash = multi_result.clone
+          else
+            hash = results_hash
+          end
+
+          hash.each do |result_key, sql|
+            unless result_key.include? col
+              test_search = Card.send("_#{col}", letter_str)
+              unless test_search.blank?
+
+                sql_to_chain = test_search.to_sql.gsub("SELECT \"cards\".* FROM \"cards\" WHERE ", "")
+
+                multi_result["#{result_key} > #{col}"] = sql + " AND " + sql_to_chain
+              end
+            end
+          end
+        end
+      end
+    end
+
+    unless user_input.count > 1
+      results = results_hash
+    else
+      results = multi_result
+
+      # split_keys = []
+      #
+      # multi_result.keys.each do |key|
+      #   split_keys << key.split(" > ")
+      # end
+    end
+
+    return results
+  end
   # ###########################################################################################
   # ###########################################################################################
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -69,23 +69,38 @@ class Card < ActiveRecord::Base
     return [results, matched_terms]
   end
 
-  def self.regex_test queries, columns, slot
+  def self.regex_test user_input, columns, slot
     results_hash = Hash.new
-    query_str = ""
+    letter_str = ""
 
-    letters = queries.first.chars
+    queries = user_input.split('');
 
-    letters.each do |query|
-      if query === letters.first
-        query_str << "[#{query}]"
-      else
-        query_str <<  ".*?[#{query}]"
+    queries.each do |query|
+      letters = query.chars
+
+      letters.each do |letter|
+        if letter === letters.first
+          letter_str << "[#{letter}]"
+        else
+          letter_str <<  ".*?[#{letter}]"
+        end
       end
-    end
 
+    # letters = queries.first.chars
+
+    # letters.each do |letter|
+    #   if letter === letters.first
+    #     letter_str << "[#{letter}]"
+    #   else
+    #     letter_str <<  ".*?[#{letter}]"
+    #   end
+    # end
+
+    # TODO add prepend support
     # TODO concatenate multiple regex statements separated by spaces
+    # TODO display text of matching word with bolded matching letters
     columns.each do |col|
-      results = Card.where("#{col} REGEXP ?", query_str)
+      results = Card.where("#{col} REGEXP ?", letter_str)
       results_hash[col] = results unless results.empty?
     end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe HomeController, type: :controller do
 
       it 'should clear saved search queries' do
         @slots.each do |slot|
-          Card.search('v, 3', slot)
-          expect(slot[:queries]).to eq('v, 3')
+          Card.search('v 3', slot)
+          expect(slot[:queries]).to eq('v 3')
         end
 
         post :clear_filters

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Slot, type: :model do
 
   describe 'Multi-query search' do
     before :each do
-      @results, @matching_terms = Card.search('v, 3', Slot.first)
+      @results, @matching_terms = Card.search('v 3', Slot.first)
     end
 
     it 'finds three unique matching cards' do
@@ -78,6 +78,17 @@ RSpec.describe Slot, type: :model do
       expect(Slot.first.cards).to include(result_values.first)
       expect(Slot.first.cards).to include(result_values.second)
       expect(Slot.first.cards).to include(result_values.third)
+    end
+  end
+
+  describe 'non-consecutive matching' do
+    before :each do
+      @results, @matching_terms = Card.search('vlg', Slot.first)
+    end
+
+    it 'should display \'village\' as first result' do
+      result_values = values_from_results
+      expect(result_values.first.name.downcase).to eq('village')
     end
   end
 


### PR DESCRIPTION
- Now uses regular expressions instead of Arel LIKE matchers
- Supports non-consecutive character matching
- Partial support for multi-query matching
  - Currently displays too many results - should only show results that are n deep, where n is the number of space-separated queries
  - Example "a v 3" should only get results like "Type > Name > Cost" (depth 3) not just "Cost > Name" (depth 2)
